### PR TITLE
1.2.5 sdk update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -32,9 +32,10 @@ ENV TORCH_HOME="/cache/torch"
 
 # tesseract 4
 RUN apt-get install -y libleptonica-dev \
-    tesseract-ocr
+    tesseract-ocr \
     #libtesseract4 \
-    #libtesseract-dev \
+    libtesseract-dev 
+
 
 # Get language data.
 RUN apt-get install -y \

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Use the same base image version as the clams-python python library version
-FROM ghcr.io/clamsproject/clams-python-opencv4:1.2.4
+FROM ghcr.io/clamsproject/clams-python-opencv4:1.2.5
 # See https://github.com/orgs/clamsproject/packages?tab=packages&q=clams-python for more base images
 # IF you want to automatically publish this image to the clamsproject organization, 
 # 1. you should have generated this template without --no-github-actions flag

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Use the same base image version as the clams-python python library version
-FROM ghcr.io/clamsproject/clams-python-opencv4:1.0.9
+FROM ghcr.io/clamsproject/clams-python-opencv4:1.2.4
 # See https://github.com/orgs/clamsproject/packages?tab=packages&q=clams-python for more base images
 # IF you want to automatically publish this image to the clamsproject organization, 
 # 1. you should have generated this template without --no-github-actions flag
@@ -15,14 +15,26 @@ ENV CLAMS_APP_VERSION ${CLAMS_APP_VERSION}
 ################################################################################
 
 ################################################################################
+# This is duplicate from the base image Containerfile 
+# but makes sure the cache directories are consistent across all CLAMS apps
+
+# https://github.com/openai/whisper/blob/ba3f3cd54b0e5b8ce1ab3de13e32122d0d5f98ab/whisper/__init__.py#L130
+ENV XDG_CACHE_HOME='/cache'  
+# https://huggingface.co/docs/huggingface_hub/main/en/package_reference/environment_variables#hfhome
+ENV HF_HOME="/cache/huggingface"
+# https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved
+ENV TORCH_HOME="/cache/torch"
+################################################################################
+
+################################################################################
 # clams-python base images are based on debian distro
 # install more system packages as needed using the apt manager
 
 # tesseract 4
 RUN apt-get install -y libleptonica-dev \
-    libtesseract4 \
-    libtesseract-dev \
     tesseract-ocr
+    #libtesseract4 \
+    #libtesseract-dev \
 
 # Get language data.
 RUN apt-get install -y \

--- a/app.py
+++ b/app.py
@@ -17,19 +17,18 @@ class OCR(ClamsApp):
         """See metadata.py"""
         pass
 
-    def _annotate(self, mmif_obj: Mmif, **kwargs) -> Mmif:
+    def _annotate(self, mmif_obj: Mmif, **params) -> Mmif:
         """
         :param mmif_obj: this mmif could contain images or video, with or without preannotated text boxes
-        :param **kwargs:
+        :param **params: the runtime configuration
         :return: annotated mmif as string
         """
         new_view = mmif_obj.new_view()
-        self.sign_view(new_view, kwargs)
-        config = self.get_configuration(**kwargs)
+        self.sign_view(new_view, params)
 
         tess_wrapper = Tesseract()
-        tess_wrapper.BOX_THRESHOLD = config.get("threshold", 90)
-        tess_wrapper.PSM = config.get("psm")
+        tess_wrapper.BOX_THRESHOLD = params["threshold"]
+        tess_wrapper.PSM = params["psm"]
 
         vds = mmif_obj.get_documents_by_type(DocumentTypes.VideoDocument)
         if vds:
@@ -42,7 +41,7 @@ class OCR(ClamsApp):
         ## collect all TF annotations as time intervals
         target_time_segments = []
         found_time_segments = []
-        frame_types = set(config.get("frameType", []))
+        frame_types = set(params["frameType"])
         frame_types.discard('')
         self.logger.debug(f"frame_types: {frame_types}")
     
@@ -71,6 +70,7 @@ class OCR(ClamsApp):
         
         for textbox_view in mmif_obj.get_all_views_contain(AnnotationTypes.BoundingBox):
             for box in textbox_view.get_annotations(AnnotationTypes.BoundingBox, boxType="text"):
+                # TODO - timepoint
                 frame_number = vdh.convert_timepoint(mmif_obj, box, 'frame')
                 # filter out any frames that are not in the "valid" time segments
                 if bisect.bisect(target_time_segment_starts, frame_number) != bisect.bisect(target_time_segment_ends, frame_number) + 1:
@@ -90,6 +90,14 @@ class OCR(ClamsApp):
                     alignment.add_property("source", f'{textbox_view.id}:{box.id}')
         return mmif_obj
 
+def get_app():
+    """
+    This function effectively creates an instance of the app class, without any arguments passed in, meaning, any 
+    external information such as initial app configuration should be set without using function arguments. The easiest
+    way to do this is to set global variables before calling this. 
+    """
+    return OCR()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -101,7 +109,7 @@ if __name__ == "__main__":
     parsed_args = parser.parse_args()
 
     # create the app instance
-    app = OCR()
+    app = get_app()
 
     http_app = Restifier(app, port=int(parsed_args.port))
     # for running the application in production mode

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+The purpose of this file is to define a thin CLI interface for your app
+
+DO NOT CHANGE the name of the file
+"""
+
+import argparse
+import sys
+from contextlib import redirect_stdout
+
+import app
+
+import clams.app
+from clams import AppMetadata
+
+
+def metadata_to_argparser(app_metadata: AppMetadata) -> argparse.ArgumentParser:
+    """
+    Automatically generate an argparse.ArgumentParser from parameters specified in the app metadata (metadata.py).
+    """
+
+    parser = argparse.ArgumentParser(
+        description=f"{app_metadata.name}: {app_metadata.description} (visit {app_metadata.url} for more info)",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    # parse cli args from app parameters
+    for parameter in app_metadata.parameters:
+        if parameter.multivalued:
+            a = parser.add_argument(
+                f"--{parameter.name}",
+                help=parameter.description,
+                nargs='+',
+                action='extend',
+                type=str
+            )
+        else:
+            a = parser.add_argument(
+                f"--{parameter.name}",
+                help=parameter.description,
+                nargs=1,
+                action="store",
+                type=str)
+        if parameter.choices is not None:
+            a.choices = parameter.choices
+        if parameter.default is not None:
+            a.help += f" (default: {parameter.default}"
+            if parameter.type == "boolean":
+                a.help += (f", any value except for {[v for v in clams.app.falsy_values if isinstance(v, str)]} "
+                           f"will be interpreted as True")
+            a.help += ')'
+            # then we don't have to add default values to the arg_parser
+            # since that's handled by the app._refined_params() method.
+    parser.add_argument('IN_MMIF_FILE', nargs='?', type=argparse.FileType('r'),
+                        help='input MMIF file path, or STDIN if `-` or not provided. NOTE: When running this cli.py in '
+                             'a containerized environment, make sure the container is run with `-i` flag to keep stdin '
+                             'open.',
+                        # will check if stdin is a keyboard, and return None if it is
+                        default=None if sys.stdin.isatty() else sys.stdin)
+    parser.add_argument('OUT_MMIF_FILE', nargs='?', type=argparse.FileType('w'), 
+                        help='output MMIF file path, or STDOUT if `-` or not provided. NOTE: When this is set to '
+                             'STDOUT, any print statements in the app code will be redirected to stderr.',
+                        default=sys.stdout)
+    return parser
+
+
+if __name__ == "__main__":
+    clamsapp = app.get_app()
+    arg_parser = metadata_to_argparser(app_metadata=clamsapp.metadata)
+    args = arg_parser.parse_args()
+    if args.IN_MMIF_FILE:
+        in_data = args.IN_MMIF_FILE.read()
+        # since flask webapp interface will pass parameters as "unflattened" dict to handle multivalued parameters
+        # (https://werkzeug.palletsprojects.com/en/latest/datastructures/#werkzeug.datastructures.MultiDict.to_dict)
+        # we need to convert arg_parsers results into a similar structure, which is the dict values are wrapped in lists
+        params = {}
+        for pname, pvalue in vars(args).items():
+            if pvalue is None or pname in ['IN_MMIF_FILE', 'OUT_MMIF_FILE']:
+                continue
+            elif isinstance(pvalue, list):
+                params[pname] = pvalue
+            else:
+                params[pname] = [pvalue]
+        if args.OUT_MMIF_FILE.name == '<stdout>':
+            with redirect_stdout(sys.stderr):
+                out_mmif = clamsapp.annotate(in_data, **params)
+        else:
+            out_mmif = clamsapp.annotate(in_data, **params)
+        args.OUT_MMIF_FILE.write(out_mmif)
+    else:
+        arg_parser.print_help()
+        sys.exit(1)

--- a/metadata.py
+++ b/metadata.py
@@ -23,8 +23,9 @@ def appmetadata() -> AppMetadata:
         analyzer_license='apache',
     )
     metadata.add_input(DocumentTypes.VideoDocument)
-    metadata.add_input(AnnotationTypes.BoundingBox, boxType='text')
+    metadata.add_input(AnnotationTypes.BoundingBox, label='text')
     metadata.add_input(AnnotationTypes.TimeFrame, required=False)
+    metadata.add_input(AnnotationTypes.TimePoint)
 
     metadata.add_output(DocumentTypes.TextDocument)
     metadata.add_output(AnnotationTypes.Alignment)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-clams-python==1.2.4
-
+clams-python==1.2.5
+mmif-python==1.0.17
 imutils>=0.5
 numpy>=1.22
 opencv-python>=4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clams-python==1.0.9
+clams-python==1.2.4
 
 imutils>=0.5
 numpy>=1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 clams-python==1.2.5
-mmif-python==1.0.17
 imutils>=0.5
 numpy>=1.22
 opencv-python>=4.4


### PR DESCRIPTION
This PR updates the Tesseract OCR app to clams SDK 1.2.5

### changes
+ "boxtype" parameter of `BoundingBox` changed to "label"
+ minor refactoring + version changes

### additions
+ OCR is now performed on the most recent view containing `BoundingBox` annotations instead of all views - this is done to reduce redundant work in pipelines containing multiple apps which pre-process the same frames as preparation for OCR (e.g., reading-order apps).
+ `TimePoint` properties are now accessed via an `Alignment` from a `BoundingBox` to a proper `TimePoint` annotation. The `BoundingBox` annotations no longer require a `timePoint` internal property.
